### PR TITLE
Fix Port mapping for the web container for docker-local.yml

### DIFF
--- a/docker-local.yml
+++ b/docker-local.yml
@@ -9,7 +9,7 @@ services:
     volumes:
     - ./client/src:/var/app/src
     ports:
-    - "5000:3000"
+    - "5000:5000"
   server:
     command: yarn start
     volumes:


### PR DESCRIPTION
## Description

When running `yarn docker-local up` you are not able to access the client ui, this is because the port mapping is not configured correctly.

## Change
When running `yarn docker-local up`

```
web_1      | INFO: Accepting connections at http://localhost:5000
```

>SHORT SYNTAX
Either specify both ports (HOST:CONTAINER)

This maps the host port 5000 to the web containers 5000 port.


EDIT: Yeah CI seems to be failing. Probably need to fix that first.