### PR TITLE
Fix yarn copyright task

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ We document our decisions in the *doc/adr/* directory. Use [adr-tools](https://g
 
 ## yarn tasks
 
-To update the Copyright notice on the source files in the `src` directory run:
+We include a Copyright notice on the source files located in the `src` directory.
+
 ```bash
-yarn run copyright --fix
+yarn run copyright      # see what needs fixing
+yarn run copyright-fix  # to auto fix copyright notice
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -35,12 +35,16 @@ Then run `tilt up` , `ctrl + c` in the terminal then `tilt down` to stop.
 Use `yarn test` to run unit tests. `yarn test-int` will run the integration tests.
 
 ## yarn tasks
+To get a list of yarn tasks
+```bash
+yarn run
+```
 
 We include a Copyright notice on the source files located in the `src` directory.
 
 ```bash
-yarn run copyright      # see what needs fixing
-yarn run copyright-fix  # to auto fix copyright notice
+yarn copyright      # see what needs fixing
+yarn copyright-fix  # to auto fix copyright notice
 ```
 
 # Decision Register

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Description
 Topo is a _reference implementation_ of an automated architecture repository - aggregating curated and live information about an organisation's software systems - what they are, how they are grouped together, and how they relate to each other.
 
-## Starting topo locally
+## Starting Topo locally
 
 ```
 yarn docker-local up
@@ -37,6 +37,13 @@ Use `yarn test` to run unit tests. `yarn test-int` will run the integration test
 # Decision Register
 
 We document our decisions in the *doc/adr/* directory. Use [adr-tools](https://github.com/npryce/adr-tools) to automate creating a new decision register file for your decision. More details in the [wiki](https://github.com/architecture-topography/topo/wiki/decision-register).
+
+## yarn tasks
+
+To update the Copyright notice on the source files in the `src` directory run:
+```bash
+yarn run copyright --fix
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,6 @@ Then run `tilt up` , `ctrl + c` in the terminal then `tilt down` to stop.
 
 Use `yarn test` to run unit tests. `yarn test-int` will run the integration tests.
 
-# Decision Register
-
-We document our decisions in the *doc/adr/* directory. Use [adr-tools](https://github.com/npryce/adr-tools) to automate creating a new decision register file for your decision. More details in the [wiki](https://github.com/architecture-topography/topo/wiki/decision-register).
-
 ## yarn tasks
 
 We include a Copyright notice on the source files located in the `src` directory.
@@ -46,6 +42,10 @@ We include a Copyright notice on the source files located in the `src` directory
 yarn run copyright      # see what needs fixing
 yarn run copyright-fix  # to auto fix copyright notice
 ```
+
+# Decision Register
+
+We document our decisions in the *doc/adr/* directory. Use [adr-tools](https://github.com/npryce/adr-tools) to automate creating a new decision register file for your decision. More details in the [wiki](https://github.com/architecture-topography/topo/wiki/decision-register).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prettier": "prettier --single-quote --trailing-comma es5 --write '**/{src,test-int}/**/*.{ts,js,graphql}?(x)'",
     "prettier-fix": "yarn prettier --fix",
     "docker-local": "docker-compose -f docker-base.yml -f docker-local.yml",
-    "copyright": "copyright-header --copyrightHolder \"Thoughtworks Inc. All rights reserved\" --include \"server/src\" --templateId \"apache\"",
+    "copyright": "copyright-header --copyrightHolder \"Thoughtworks Inc. All rights reserved\" --include \"src\" --templateId \"apache\"",
     "copyright-fix": "yarn run copyright --fix",
     "lint": "yarn tslint -c tslint.json 'src/**/*.{ts,js}?(x)'",
     "lint-fix": "yarn run lint --fix",

--- a/src/dbQueries.ts
+++ b/src/dbQueries.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Thoughtworks Inc. All rights reserved
+ * Copyright 2019-2020 Thoughtworks Inc. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Thoughtworks Inc. All rights reserved
+ * Copyright 2018-2020 Thoughtworks Inc. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/neo.ts
+++ b/src/neo.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Thoughtworks Inc. All rights reserved
+ * Copyright 2018-2020 Thoughtworks Inc. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/resolvers/System.ts
+++ b/src/resolvers/System.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Thoughtworks Inc. All rights reserved
+ * Copyright 2018-2020 Thoughtworks Inc. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/resolvers/Technology.ts
+++ b/src/resolvers/Technology.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Thoughtworks Inc. All rights reserved
+ * Copyright 2019-2020 Thoughtworks Inc. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Thoughtworks Inc. All rights reserved
+ * Copyright 2018-2020 Thoughtworks Inc. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Thoughtworks Inc. All rights reserved
+ * Copyright 2018-2020 Thoughtworks Inc. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 Thoughtworks Inc. All rights reserved
+ * Copyright 2018-2020 Thoughtworks Inc. All rights reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Context

We performed a dramatic code restructure. I'm going through the yarn project tasks 1 by 1 to ensure they are still needed and are still working.
I'll do these 1 by 1. (so ignore this branch name for now)

This PR is to fix the automated code copyright comment task `yarn run copyright --fix` it now works on the `src` folder and not the `server/src` folder (which was 🔪 'ed)

## Confirmation:

-  I have run the pre-commit checks before committing.
-  I have performed a self-review of my own code.
-  I have updated corresponding documentation if applicable.
-  My changes generate no new warnings.
-  Any dependant downstream changes have been applied.

[ ] I've read and complete all the applicable points above.
