### PR TITLE
Circle CI Nightly Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,3 +55,5 @@ workflows:
             branches:
               only:
                 - master
+    jobs:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,3 +47,11 @@ workflows:
             branches:
               ignore:
                 - /wip-.*/
+  nightly:
+  triggers:
+    - schedule:
+        cron: "0 0 * * *"
+        filters:
+          branches:
+            only:
+              - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,13 +47,6 @@ workflows:
             branches:
               ignore:
                 - /wip-.*/
-
-workflows:
-  version: 2
-  commit:
-    jobs:
-      - test
-      - deploy
   nightly:
     triggers:
       - schedule:
@@ -62,5 +55,3 @@ workflows:
             branches:
               only:
                 - master
-    jobs:
-      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,20 @@ workflows:
             branches:
               ignore:
                 - /wip-.*/
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - test
+      - deploy
   nightly:
-  triggers:
-    - schedule:
-        cron: "0 0 * * *"
-        filters:
-          branches:
-            only:
-              - master
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test


### PR DESCRIPTION
## Context

Nightly builds ensure things are still working. There are always things we cannot control or think about. e.g when we re ran the Topo build for the first time in 12ish months.. the dependency cache expired and the build was broken.. not because of the code / config changes, but because we didn't realise that an expiring cache would bork the build.

Exercising daily builds ensures that we find out sooner rather than later if something breaks / isn't playing nicely.. e.g docker hub... git hub APIs .. etc..

It's configured to 12am UTC == 10am AEST (I think).

## Confirmation:

-  I have run the pre-commit checks before committing.
-  I have performed a self-review of my own code.
-  I have updated corresponding documentation if applicable.
-  My changes generate no new warnings.
-  Any dependant downstream changes have been applied.

- [x]  I've read and complete all the applicable points above.
