### PR TITLE
pin docker node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:12.18-alpine
 ADD . /var/app
 WORKDIR /var/app
 RUN yarn install


### PR DESCRIPTION
## Context

Build broke because the docker node 12 latest was using node 12.18, then it was bumped to 12.19. Something in that bump caused the error as running it back on 12.18 worked.

This PR pins the docker alpine nodejs version to 12.18
